### PR TITLE
Cleanup tet_get_geo file, update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /src/to_see_the_world/output/*
 /src/to_see_the_world/athlete_data_local/*
 /src/to_see_the_world/secrets.ini
+/src/to_see_the_world/__pycache__

--- a/src/to_see_the_world/test_get_geo.py
+++ b/src/to_see_the_world/test_get_geo.py
@@ -9,328 +9,330 @@ from coordinates_to_countries import CoordinatesToCountries
 from to_see_the_world import CountryData, Utils
 
 
-pwd = Path.cwd()
-pickle = f'{pwd}/test_get_geo.pickle'
-df  = pd. read_pickle(pickle)
-df = df.get(df['coords'].str.len() != 0)
-   
-config = configparser.ConfigParser()
-config.read(f'{pwd}/config.ini')
-fname_country_data = config.get(
-    'path', 'fname_country_data')
-CD = CountryData(fname_country_data)
-U = Utils()
+class TestGetGeo():
+    def __init__(self):
+        self.pwd = Path.cwd()
+        config = configparser.ConfigParser()
+        config.read(f'{self.pwd}/config.ini')
+        fname_country_data = config.get(
+            'path', 'fname_country_data')
+        self.CD = CountryData(fname_country_data)
+        self.U = Utils()
+        
+        # Using Jacob's data between 2017-2024
+        # Below is a list of every expected border 
+        # crossing verified from his data
+        self.ans = {
+            969217846: 'CH,LI,AT',
+            972228442: 'AT,DE',
+            975224137: 'DE,AT',
+            975224174: 'DE,CZ',
+            983225238: 'CZ,PL',
+            992259989: 'PL,SK',
+            992258897: 'SK,HU',
+            999795712: 'HU,AT',
+            1002142028: 'AT,SI',
+            1002141170: 'SI,HR',
+            1006590929: 'HR,BA',
+            1020833686: 'BA,RS',
+            1026530098: 'RS,ME',
+            1036212543: 'ME,RS',
+            1036212126: 'RS,MK',
+            1042546544: 'MK,AL',
+            1054888756: 'AL,GR',
+            1090980729: 'JO,PS',
+            1100451555: 'IL,PS',
+            1143621514: 'EG,SD',
+            1154679820: 'SD,ET',
+            1277417244: 'ET,KE',
+            1313426853: 'KE,UG',
+            1332850759: 'UG,RW',
+            1353196261: 'RW,BI',
+            1366071804: 'BI,TZ',
+            1410312683: 'TZ,MZ',
+            1430002910: 'MZ,MW',
+            1434221854: 'MW,ZM',
+            1445999233: 'ZM,ZW,BW',
+            1458008121: 'BW,NA',
+            1480927778: 'NA,ZA',
+            1518380934: 'ZA,LS',
+            1532906341: 'LS,ZA',
+            1539179780: 'ZA,SZ',
+            1542224198: 'SZ,ZA',
+            1641423681: 'ES,AD',
+            1642648271: 'AD,FR',
+            1656622954: 'FR,MC,IT',
+            1660818664: 'IT,CH,FR', 
+            1663262537: 'FR,CH',
+            1680847046: 'FR,BE,LU',
+            1681220129: 'LU,BE',
+            1685951904: 'BE,FR',
+            1763259489: 'GB,IE',
+            1803017418: 'NL,DE',
+            1808153082: 'DE,DK',
+            1815109443: 'SE,NO',
+            1838268321: 'NO,SE',
+            1853760694: 'SE,FI',
+            1855658555: 'FI,NO',
+            1867144862: 'NO,FI',
+            1899410507: 'EE,LV',
+            1902479018: 'LV,LT',
+            1910402844: 'LT,PL',
+            1917601912: 'PL,UA',
+            1922621058: 'UA,MD',
+            1927860955: 'MD,RO',
+            1938874675: 'RO,BG',
+            1947497006: 'BG,TR',
+            1989387244: 'TR,AZ',
+            1992580159: 'AZ,TR',
+            1997830471: 'TR,GE,AM',
+            2008312891: 'AM,GE',
+            2192652170: 'GE,RU',
+            2192652308: 'GE,RU',
+            2198713647: 'GE,AZ',
+            2209924726: 'AZ,RU',
+            2222213119: 'RU,KZ',
+            2231316989: 'KZ,UZ',
+            2258834992: 'UZ,TJ',
+            2557723116: 'US,CA',
+            2645200132: 'CA,US',
+            2685598168: 'CA,US',
+            2925282682: 'TL,ID',
+            2989356207: 'MY,BN',
+            2989569335: 'BN,MY',
+            3004084481: 'MY,ID',
+            3070557998: 'SG,MY',
+            3084556359: 'MY,TH',
+            3115698710: 'TH,KH',
+            3127902620: 'KH,VN',
+            3155945975: 'VN,LA',
+            3163671165: 'LA,TH',
+            7250241840: 'US,CA',
+            9703455717: 'CA,US',
+            8237455383: 'US,MX',
+            9858671260: 'IN,NP',
+            10309615568: 'NP,IN',
+            10429522218: 'IN,BD',
+            10523118593: 'BD,IN',
+            11054021860: 'IN,PK',
+            11251366756: 'CN,KG',
+            11297313300: 'KG,UZ',
+            11445621051: 'UZ,TJ',
+            11766938334: 'TJ,KG',
+            11949415280: 'KG,KZ',
+            12015174767: 'KZ,KG',
+            12210639728: 'KG,KZ',
+            12262976789: 'KZ,CN',
+            12723522793: 'CN,VN',
+            13098612540: 'VN,LA',
+            13227992363: 'LA,TH'
+        }
+        
+    def run(self, a_id=[]):
+        pickle = f'{self.pwd}/test_get_geo.pickle'
+        df  = pd. read_pickle(pickle)
+        df = df.get(df['coords'].str.len() != 0)
+        if a_id:
+            df = df.get(df.id.isin(a_id))
+            
+        start = time()
+        df = self.get_geo(df, 20)
+        end = time()
+        
+        missed = self.get_missed(df)
+        num_calc_bc = len(df.get(
+            df.border_crossings > 1))
+        calc_bad = self.get_calc_bad(df)
+        
+        print(
+            f'Elapsed time: {round(end - start, 2)} sec')
+        print(
+            f'Number of expected BC: {len(self.ans)}')
+        print('Number of calculated BC: '             
+            f'{num_calc_bc}')  
+        print(f'Missed BC: {len(missed)}')
+        for m in missed:
+            print(f'{m}, {missed[m]}')
+        print(f'Extra BCs: {len(calc_bad)}')
+        for c in calc_bad:
+            print(f'{c}, {calc_bad[c]}')
+    
+    def get_missed(self, df):
+        missed = {}
+        for a in self.ans:
+            if a in df.id.values:
+                if self.ans[a] != df.get(df.id == a
+                    ).country_code.values[0]:
+                    calc_value = df.get(df.id == a
+                        ).country_code.values[0]
+                    link = self.get_strava_activity_link(a)
+                    missed[link] = (
+                        f'A: {self.ans[a]}, B: {calc_value}')
+        return missed
 
+    def get_calc_bad(self, df):
+        calc_bad = {}
+        for val in df.get(df.border_crossings > 1).id:
+            if int(val) not in self.ans.keys():
+                link = self.get_strava_activity_link(val)
+                calc_bad[link] = df.get(df.id == val
+                    ).country_code.values[0]
+        return calc_bad
 
-def get_strava_activity_link(i):
-    return f'https://www.strava.com/activities/{i}'
-
-def get_border_crossings(df):
-    return df.country_code.str.split(','
-        ).apply(lambda x: len(x))
-
-def get_geo(df, slice=1):
-        df['coords_simple'] = df['coords'].apply(
-            lambda x: x[::slice] + [x[-1]])
-        df_explode = df[['id', 'coords_simple']
-            ].explode('coords_simple').dropna()
-        coords_slice = list(
-            df_explode.coords_simple)
-        print('Finding coordinate meta data for '
-            f'{len(coords_slice)} points')
-        CTC = CoordinatesToCountries()
-        df_slice = CTC.run(coords_slice)
-        df_slice['id'] = list(df_explode.id)
-        df_slice = df_slice.drop_duplicates(
-            subset=['id', 'country_code', 'admin_name'])
-        df_slice = df_slice.groupby('id').agg(
-            {'country_code': 
-                 lambda x: ','.join(list(dict.fromkeys(x))),
-             'admin_name': ','.join}
-             ).reset_index()
-        df = pd.merge(
-            df, df_slice[['id', 'country_code',
-            'admin_name']], on='id', how='right')
-        df.coords = \
-            df.coords.apply(tuple)
-        df, dbg = edit_borders(df, debug=True)
-        df['border_crossings'] = \
-            get_border_crossings(df)
-        df['country_name'] = df.country_code.apply(
-            lambda x: \
-            CD.country_code_to_country_name(x))
-        return df
-
-def edit_borders(df, debug=False):
-        df = df.sort_values(by='start_date_local')
-        if df.shape[0] <= 3:
+    def get_strava_activity_link(self, i):
+        return f'https://www.strava.com/activities/{i}'
+    
+    def get_border_crossings(self, df):
+        return df.country_code.str.split(','
+            ).apply(lambda x: len(x))
+    
+    def get_geo(self, df, slice=1):
+            df['coords_simple'] = df['coords'].apply(
+                lambda x: x[::slice] + [x[-1]])
+            df_explode = df[['id', 'coords_simple']
+                ].explode('coords_simple').dropna()
+            coords_slice = list(
+                df_explode.coords_simple)
+            print('Finding coordinate meta data for '
+                f'{len(coords_slice)} points')
+            CTC = CoordinatesToCountries()
+            df_slice = CTC.run(coords_slice)
+            df_slice['id'] = list(df_explode.id)
+            df_slice = df_slice.drop_duplicates(
+                subset=['id', 'country_code',
+                'admin_name'])
+            df_slice = df_slice.groupby('id').agg(
+                {'country_code': 
+                     lambda x: ','.join(list(
+                     dict.fromkeys(x))),
+                 'admin_name': ','.join}
+                 ).reset_index()
+            df = pd.merge(
+                df, df_slice[['id', 'country_code',
+                'admin_name']], on='id', how='right')
+            df.coords = \
+                df.coords.apply(tuple)
+            #df, dbg = edit_borders(df, debug=True)
+            df['border_crossings'] = \
+                self.get_border_crossings(df)
+            df['country_name'] = \
+                df.country_code.apply(lambda x:
+                self.CD.country_code_to_country_name(
+                x))
             return df
-        ids = list(df.id.values)
-        debug_data = {}
-        df['border_crossings'] = \
-            get_border_crossings(df)
-        bc_gt_1= list(df.get(
-            df.border_crossings > 1).id.values)
-        for idx, i in enumerate(ids):
-            if i not in bc_gt_1:
-                continue
-            prev_id = ids[idx - 1]
-            cur_id = i
-            next_id = ids[idx + 1]
-            prev_cc = U.get_cc(df, prev_id)
-            cur_cc = U.get_cc(df, cur_id)
-            next_cc = U.get_cc(df, next_id)
-            bc = df.get(df.id == cur_id
-                ).border_crossings.values[0]
-            prev_dist = U.get_distance(
-                df, prev_id, cur_id)
-            next_dist = U.get_distance(
-                df, cur_id, next_id)
-            if debug:
-                debug_data[cur_id] = {
-                    'prev_cc': prev_cc,
-                    'cur_cc_og': cur_cc,
-                    'next_cc': next_cc,
-                    'bc': bc,
-                    'prev_id': prev_id,
-                    'cur_id': cur_id,
-                    'next_id': next_id,
-                    'prev_dist': prev_dist,
-                    'next_dist': next_dist}
-            if len(cur_cc) == 1:
-            # Skipping, odd data
-                continue
-            if bc == 2 or bc == 3 and len(cur_cc) == 2:
-                if prev_cc == next_cc:
-                # Check for in and out of one country
-                # No border crossing.
-                # Set current cur_cc to prev_cc
-                    df.loc[df.id == cur_id, 'country_code'
-                        ] = ','.join(prev_cc)
-                    if cur_id in debug_data:
-                        debug_data[cur_id].update(
-                            {'edit': 'A, no bc'})
-                elif prev_cc[-1] == cur_cc[0] and \
-                    cur_cc[1] == next_cc[0]:
-                # A border was crossed,
-                # cur_cc is valid
-                    if debug_data:
-                        debug_data[cur_id].update(
-                            {'edit': 'B'})
-                    pass
-                elif prev_cc[-1] in cur_cc and \
-                    prev_dist < 5 and next_dist > 5:
-                # The prev point is a valid comparison,
-                # but the next point is not. Data is
-                # incomplete, but a border was
-                # likely crossed, cur_cc is valid
-                    if debug_data:
-                        debug_data[cur_id].update(
-                            {'edit': 'B2'})
-                    pass
-                elif prev_dist > 5 and next_dist < 5 and \
-                    next_cc[0] in cur_cc:
-                # The next point is a valid comparison,
-                # but the prev point is not. Data is
-                # incomplete, but a border was
-                # likely crossed, cur_cc is valid
-                    if debug_data:
-                        debug_data[cur_id].update(
-                            {'edit': 'B3'})
-                    pass
+    
+    def edit_borders(self, df, debug=False):
+            df = df.sort_values(by='start_date_local')
+            if df.shape[0] <= 3:
+                return df
+            ids = list(df.id.values)
+            debug_data = {}
+            df['border_crossings'] = \
+                self.get_border_crossings(df)
+            bc_gt_1= list(df.get(
+                df.border_crossings > 1).id.values)
+            for idx, i in enumerate(ids):
+                if i not in bc_gt_1:
+                    continue
+                prev_id = ids[idx - 1]
+                cur_id = i
+                next_id = ids[idx + 1]
+                prev_cc = self.U.get_cc(df, prev_id)
+                cur_cc = self.U.get_cc(df, cur_id)
+                next_cc = self.U.get_cc(df, next_id)
+                bc = df.get(df.id == cur_id
+                    ).border_crossings.values[0]
+                prev_dist = self.U.get_distance(
+                    df, prev_id, cur_id)
+                next_dist = self.U.get_distance(
+                    df, cur_id, next_id)
+                if debug:
+                    debug_data[cur_id] = {
+                        'prev_cc': prev_cc,
+                        'cur_cc_og': cur_cc,
+                        'next_cc': next_cc,
+                        'bc': bc,
+                        'prev_id': prev_id,
+                        'cur_id': cur_id,
+                        'next_id': next_id,
+                        'prev_dist': prev_dist,
+                        'next_dist': next_dist}
+                if len(cur_cc) == 1:
+                # Skipping, odd data
+                    continue
+                if bc == 2 or bc == 3 and \
+                    len(cur_cc) == 2:
+                    if prev_cc == next_cc:
+                    # Check for in and out of one country
+                    # No border crossing.
+                    # Set current cur_cc to prev_cc
+                        df.loc[df.id == cur_id, 'country_code'
+                            ] = ','.join(prev_cc)
+                        if cur_id in debug_data:
+                            debug_data[cur_id].update(
+                                {'edit': 'A, no bc'})
+                    elif prev_cc[-1] == cur_cc[0] and \
+                        cur_cc[1] == next_cc[0]:
+                    # A border was crossed,
+                    # cur_cc is valid
+                        if debug_data:
+                            debug_data[cur_id].update(
+                                {'edit': 'B'})
+                        pass
+                    elif prev_cc[-1] in cur_cc and \
+                        prev_dist < 5 and next_dist > 5:
+                    # The prev point is a valid comparison,
+                    # but the next point is not. Data is
+                    # incomplete, but a border was
+                    # likely crossed, cur_cc is valid
+                        if debug_data:
+                            debug_data[cur_id].update(
+                                {'edit': 'B2'})
+                        pass
+                    elif prev_dist > 5 and next_dist < 5 \
+                        and next_cc[0] in cur_cc:
+                    # The next point is a valid comparison,
+                    # but the prev point is not. Data is
+                    # incomplete, but a border was
+                    # likely crossed, cur_cc is valid
+                        if debug_data:
+                            debug_data[cur_id].update(
+                                {'edit': 'B3'})
+                        pass
+                    else:
+                    # Inconclusive,
+                    # set cur_cc to prev_cc
+                        df.loc[df.id == cur_id, 'country_code'
+                            ] = ','.join(prev_cc)
+                        if debug_data:
+                            debug_data[cur_id].update(
+                                {'edit': 'C, no bc'})
+                elif bc == 3 and len(cur_cc) == 3:
+                    if prev_cc[-1] == cur_cc[0]:
+                    # A country was crossed.
+                    # cur_cc is valid
+                        if debug_data:
+                            debug_data[cur_id].update(
+                                {'edit': 'D'})
+                        pass
+                    else:
+                    # Inconclusive.
+                    # Set cur_cc to prev_cc
+                        df.loc[df.id == cur_id, 'country_code'
+                            ] = ','.join(prev_cc)
+                        if debug_data:
+                            debug_data[cur_id].update(
+                                {'edit': 'E, no bc'})
                 else:
-                # Inconclusive,
-                # set cur_cc to prev_cc
-                    df.loc[df.id == cur_id, 'country_code'
-                        ] = ','.join(prev_cc)
-                    if debug_data:
-                        debug_data[cur_id].update(
-                            {'edit': 'C, no bc'})
-            elif bc == 3 and len(cur_cc) == 3:
-                if prev_cc[-1] == cur_cc[0]:
-                # A country was crossed.
-                # cur_cc is valid
-                    if debug_data:
-                        debug_data[cur_id].update(
-                            {'edit': 'D'})
-                    pass
-                else:
-                # Inconclusive.
+                # bc > 3, the data very likely bad.
                 # Set cur_cc to prev_cc
                     df.loc[df.id == cur_id, 'country_code'
                         ] = ','.join(prev_cc)
                     if debug_data:
                         debug_data[cur_id].update(
-                            {'edit': 'E, no bc'})
-            else:
-            # bc > 3, the data very likely bad.
-            # Set cur_cc to prev_cc
-                df.loc[df.id == cur_id, 'country_code'
-                    ] = ','.join(prev_cc)
-                if debug_data:
-                    debug_data[cur_id].update(
-                        {'edit': 'F, no bc'})
-        return df, debug_data
+                            {'edit': 'F, no bc'})
+            return df, debug_data
 
-# List of likely issues:
-#1090980908: 'IL',
-#1090981171: 'IL',
-#1100452053: 'JO',
-#1432712431: 'MW',
-#2006397655: 'AM',
-#2273911358: 'TJ',
-#2276201379: 'TJ',
-#2276635501: 'TJ',
-#2279036223: 'TJ',
-#710455279525: 'BD',
-#11525331563: 'TJ',
-#11539873987: 'TJ',
-#11539875503: 'TJ',
-#11725737338: 'TJ',
-#11725737598: 'TJ',
-#11725740611: 'TJ',
-#11725792997: 'TJ',
-#11725841423: 'TJ',
-#11725858841: 'TJ',
-
-# Using Jacob's data between 2017-2024
-# Below is a list of every expected border 
-# crossing verified from his data
-ans = {
-    969217846: 'CH,LI,AT',
-    972228442: 'AT,DE',
-    975224137: 'DE,AT',
-    975224174: 'DE,CZ',
-    983225238: 'CZ,PL',
-    992259989: 'PL,SK',
-    992258897: 'SK,HU',
-    999795712: 'HU,AT',
-    1002142028: 'AT,SI',
-    1002141170: 'SI,HR',
-    1006590929: 'HR,BA',
-    1020833686: 'BA,RS',
-    1026530098: 'RS,ME',
-    1036212543: 'ME,RS',
-    1036212126: 'RS,MK',
-    1042546544: 'MK,AL',
-    1054888756: 'AL,GR',
-    1090980729: 'JO,PS',
-    1100451555: 'IL,PS',
-    1143621514: 'EG,SD',
-    1154679820: 'SD,ET',
-    1277417244: 'ET,KE',
-    1313426853: 'KE,UG',
-    1332850759: 'UG,RW',
-    1353196261: 'RW,BI',
-    1366071804: 'BI,TZ',
-    1410312683: 'TZ,MZ',
-    1430002910: 'MZ,MW',
-    1434221854: 'MW,ZM',
-    1445999233: 'ZM,ZW,BW',
-    1458008121: 'BW,NA',
-    1480927778: 'NA,ZA',
-    1518380934: 'ZA,LS',
-    1532906341: 'LS,ZA',
-    1539179780: 'ZA,SZ',
-    1542224198: 'SZ,ZA',
-    1641423681: 'ES,AD',
-    1642648271: 'AD,FR',
-    1656622954: 'FR,MC,IT',
-    1660818664: 'IT,CH,FR', 
-    1663262537: 'FR,CH',
-    1680847046: 'FR,BE,LU',
-    1681220129: 'LU,BE',
-    1685951904: 'BE,FR',
-    1763259489: 'GB,IE',
-    1803017418: 'NL,DE',
-    1808153082: 'DE,DK',
-    1815109443: 'SE,NO',
-    1838268321: 'NO,SE',
-    1853760694: 'SE,FI',
-    1855658555: 'FI,NO',
-    1867144862: 'NO,FI',
-    1899410507: 'EE,LV',
-    1902479018: 'LV,LT',
-    1910402844: 'LT,PL',
-    1917601912: 'PL,UA',
-    1922621058: 'UA,MD',
-    1927860955: 'MD,RO',
-    1938874675: 'RO,BG',
-    1947497006: 'BG,TR',
-    1989387244: 'TR,AZ',
-    1992580159: 'AZ,TR',
-    1997830471: 'TR,GE,AM',
-    2008312891: 'AM,GE',
-    2192652170: 'GE,RU',
-    2192652308: 'GE,RU',
-    2198713647: 'GE,AZ',
-    2209924726: 'AZ,RU',
-    2222213119: 'RU,KZ',
-    2231316989: 'KZ,UZ',
-    2258834992: 'UZ,TJ',
-    2557723116: 'US,CA',
-    2645200132: 'CA,US',
-    2685598168: 'CA,US',
-    2925282682: 'TL,ID',
-    2989356207: 'MY,BN',
-    2989569335: 'BN,MY',
-    3004084481: 'MY,ID',
-    3070557998: 'SG,MY',
-    3084556359: 'MY,TH',
-    3115698710: 'TH,KH',
-    3127902620: 'KH,VN',
-    3155945975: 'VN,LA',
-    3163671165: 'LA,TH',
-    7250241840: 'US,CA',
-    9703455717: 'CA,US',
-    8237455383: 'US,MX',
-    9858671260: 'IN,NP',
-    10309615568: 'NP,IN',
-    10429522218: 'IN,BD',
-    10523118593: 'BD,IN',
-    11054021860: 'IN,PK',
-    11251366756: 'CN,KG',
-    11297313300: 'KG,UZ',
-    11445621051: 'UZ,TJ',
-    11766938334: 'TJ,KG',
-    11949415280: 'KG,KZ',
-    12015174767: 'KZ,KG',
-    12210639728: 'KG,KZ',
-    12262976789: 'KZ,CN',
-    12723522793: 'CN,VN',
-    13098612540: 'VN,LA',
-    13227992363: 'LA,TH'
-}
-
-
-start = time()
-df = get_geo(df, 25)
-end = time()
-
-missed = {}
-for a in ans:
-    if a in df.id.values:
-        if ans[a] != df.get(df.id == a
-            ).country_code.values[0]:
-            calc_value = df.get(df.id == a
-                ).country_code.values[0]
-            link = get_strava_activity_link(a)
-            missed[link] = (f'A: {ans[a]}, B: {calc_value}')
-
-num_calc_bc = len(df.get(df.border_crossings > 1))
-calc_bad = {}
-for val in df.get(df.border_crossings > 1).id:
-    if int(val) not in ans.keys():
-        link = get_strava_activity_link(val)
-        calc_bad[link] = df.get(df.id == val
-            ).country_code.values[0]
-
-print(f'Elapsed time: {round(end - start, 2)} sec')
-print(f'Number of expected BC: {len(ans)}')
-print(f'Number of calculated BC: {num_calc_bc}')  
-print(f'Missed BC: {len(missed)}')
-for m in missed:
-    print(f'{m}, {missed[m]}')
-print(f'Extra BCs: {len(calc_bad)}')
-for c in calc_bad:
-    print(f'{c}, {calc_bad[c]}')
+if __name__ == "__main__":
+    TGG = TestGetGeo()
+    TGG.run(a_id=[969217846])


### PR DESCRIPTION
- turn get_geo test file from a script to a class
- This gives the user more options to run back-to-back tests and makes the structute generally cleaner
- Give the user the option to run a single acitivty id at a time
- Edit gitignore file to ignore __pycache__ file